### PR TITLE
created ports option to store each port's properties

### DIFF
--- a/src/components/client.js
+++ b/src/components/client.js
@@ -79,6 +79,10 @@ function Client(scope, queueList, multiplex, serializer, sessions, encrypter) {
         Promise.resolve()
           .then(() => (scope.serial !== null) ? scope.serial.decode(packet) : packet)
           .catch(err => packet)
+          .then(msg => {
+            console.log('>>> msg', msg);
+            return msg;
+          })
           .then(decodedPacket => multiplex.trigger(frame.channel, format(frame, decodedPacket, messageIndex)))
       });                 
     });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -30,9 +30,9 @@ const transports = require('./transports');
  * }
  */
 const defaults = {
-  hostname: '0.0.0.0',
-  port: 3000,
-  transport: transports.TCP,
+  //hostname: '0.0.0.0',
+  //port: 3000,
+  //transport: transports.TCP,
   serial: serials.JSON,
   secretKey: null,
   profile: profiles.dynamic,

--- a/src/transports/ipc.js
+++ b/src/transports/ipc.js
@@ -26,7 +26,7 @@ const _path = '/tmp/app.socket-';
  */
 function listen(handlers, options) {
   return new Promise(resolve => {
-    const listener = net.createServer(handlers.handleConnection);
+    const listener = net.createServer(socket => handlers.handleConnection(socket, module.exports));
     listener.on('error', handlers.handleError);
     listener.listen(_path + options.port, resolve.bind(null, listener));
   });
@@ -75,8 +75,8 @@ function attachSocket(socket, handlers) {
  * @param {Server} server The server object
  * @param {function} callback The success callback for the operation
  */
-function stop(server, callback) {
-  server.listener.close(() => setTimeout(callback, 0));
+function stop(port, callback) {
+  port.listener.close(() => setTimeout(callback, 0));
 }
 
 /**
@@ -95,9 +95,9 @@ function send(socket, payload) {
  * @param {Client} client The client to disconnect
  * @param {function} callback The callback method
  */
-function disconnect(client, callback) {
-  client.socket.end();
-  client.socket.destroy();
+function disconnect(port, callback) {
+  port.socket.end();
+  port.socket.destroy();
   setTimeout(callback, 0);
 }
 

--- a/src/transports/tcp.js
+++ b/src/transports/tcp.js
@@ -21,7 +21,7 @@ const net = require('net');
  */
 function listen (handlers, options) {
   return new Promise(resolve => {
-    const listener = net.createServer(handlers.handleConnection);
+    const listener = net.createServer(socket => handlers.handleConnection(socket, module.exports));
     listener.on('error', handlers.handleError);
     listener.listen(options.port, resolve.bind(null, listener));
   });
@@ -46,8 +46,8 @@ function getOrigin(socket) {
  * @param {Client} client The client to create the socket for
  * @returns {Socket} The created tcp client
  */
-function createSocket(client) {
-  return net.connect(client.port, client.hostname);
+function createSocket(port) {
+  return net.connect(port.port, port.hostname);
 }
 
 /**
@@ -71,8 +71,8 @@ function attachSocket(socket, handlers) {
  * @param {Server} server The server object
  * @param {function} callback The success callback for the operation
  */
-function stop(server, callback) {
-  server.listener.close(() => setTimeout(callback, 0));
+function stop(port, callback) {
+  port.listener.close(() => setTimeout(callback, 0));
 }
 
 /**
@@ -91,9 +91,9 @@ function send(socket, payload) {
  * @param {Client} client The client to disconnect
  * @param {function} callback The callback method
  */
-function disconnect(client, callback) {
-  client.socket.end();
-  client.socket.destroy();
+function disconnect(port, callback) {
+  port.socket.end();
+  port.socket.destroy();
   setTimeout(callback, 0);
 }
 

--- a/src/transports/udp.js
+++ b/src/transports/udp.js
@@ -25,7 +25,7 @@ function resolveClient(origin, handlers, options) {
   const key = `${origin.address}.${origin.port}`;
   if (!_clientCache.hasOwnProperty(key)) {
     _clientCache[key] = {
-      client: handlers.handleConnection(null, { 
+      client: handlers.handleConnection(null, module.exports, {
         hostname: origin.address, 
         port: origin.port,
         connected: 0,
@@ -90,8 +90,8 @@ function send(socket, payload) {
  * @param {Server} server The server object
  * @param {function} callback The success callback for the operation
  */
-function stop(server, callback) {
-  server.listener.close();
+function stop(port, callback) {
+  port.listener.close();
   setTimeout(callback, 0);
 }
 
@@ -101,10 +101,10 @@ function stop(server, callback) {
  * @param {Client} client The client to create the socket for
  * @returns {Socket} The created tcp client
  */
-function createSocket(client) {
+function createSocket(port) {
   let socket = dgram.createSocket(_socketType);
-  socket._port = socket._port || client.port;
-  socket._hostname = socket._hostname || client.hostname;
+  socket._port = socket._port || port.port;
+  socket._hostname = socket._hostname || port.hostname;
   return socket;
 }
 
@@ -132,7 +132,7 @@ function attachSocket(socket, handlers) {
  * @param {Client} client The client to disconnect
  * @param {function} callback The callback method
  */
-function disconnect(client, callback) {
+function disconnect(port, callback) {
   setTimeout(callback, 0); // Nothing to do
 }
 


### PR DESCRIPTION
for functionality test code, see https://gist.github.com/msterle/4b6a5007160d6a700c2bf6700070eebf

Separated config into `ports` option. Each port stores it's own transport, socket info, etc. Actually, `ports` would be better called `sockets` because IPC doesn't always use ports, but we'd have to rename the already in use socket to something like `netSocket` to indicate it is a node-level net.Socket type.

This requires that `handleConnection` receive the transport object from the transport, which is done through the sue of `module.exports` right now just for POC, and hasn't been updated in kalm-websocket.

#9 