### PR TITLE
v6.1.0

### DIFF
--- a/.github/workflows/master-status.yml
+++ b/.github/workflows/master-status.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 Frederic Charette
+Copyright 2022 Frederic Charette
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported          |
+| Version | Supported |
 | ------- | ------------------ |
-| 4.x   | :white_check_mark: |
-| 3.3.x   | :white_check_mark: |
-| < 3.3   | :x:                |
+| 6.x | :white_check_mark: |
+| 5.x | :white_check_mark: |
+| <= 4.x | :x: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kalm",
   "private": true,
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "The socket optimizer",
   "main": "packages/kalm/bin/kalm.js",
   "scripts": {
@@ -51,18 +51,18 @@
     }
   },
   "devDependencies": {
-    "@types/jest": "^26.0.0",
-    "@types/node": "^14.14.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
-    "eslint": "^7.24.0",
-    "eslint-config-airbnb-base": "^14.2.0",
-    "eslint-plugin-import": "^2.22.0",
-    "husky": "^6.0.0",
-    "jest": "^26.6.0",
-    "socket.io": "^4.0.0",
-    "socket.io-client": "^4.0.0",
-    "ts-jest": "^26.5.0",
-    "typescript": "^4.2.0"
+    "@types/jest": "^29.2.0",
+    "@types/node": "^18.11.0",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
+    "eslint": "^8.25.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "husky": "^8.0.0",
+    "jest": "^29.2.0",
+    "socket.io": "^4.5.0",
+    "socket.io-client": "^4.5.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^4.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   },
   "devDependencies": {

--- a/packages/ipc/README.md
+++ b/packages/ipc/README.md
@@ -39,4 +39,4 @@ If you think of something that you want, [open an issue](//github.com/kalm/kalm.
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalm/ipc",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "IPC transport for Kalm",
   "main": "bin/ipc.js",
   "scripts": {

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -46,11 +46,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/kalm/README.md
+++ b/packages/kalm/README.md
@@ -130,8 +130,6 @@ Kalm offers events to track when packets are processed by routines or when a raw
 | `connect` | [Client](./types.d.ts#L35) | (client) Indicates that a client has successfuly connected |
 | `disconnect` | void | (client) Indicates that a client has disconnected |
 | `frame` | [RawFrame](./types.d.ts#L111) | (client) Triggered when recieving a parsed full frame. |
-| `<channel>.queueAdd` | ```{ frameId: number, packets: number}``` | (client) Indicates that a packet was queued to a frame. |
-| `<channel>.queueRun` | ```{ frameId: number, packets: number}``` | (client) Indicates that a frame is being sent. |
 
 ## Testing
 
@@ -168,4 +166,4 @@ Support this project with your organization. Your logo will show up here with a 
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/kalm/package.json
+++ b/packages/kalm/package.json
@@ -50,11 +50,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/kalm/package.json
+++ b/packages/kalm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalm",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "The socket optimizer",
   "main": "bin/kalm.js",
   "scripts": {

--- a/packages/kalm/src/routines/dynamic.ts
+++ b/packages/kalm/src/routines/dynamic.ts
@@ -9,7 +9,7 @@ export function dynamic({
     throw new Error(`Unable to set Hertz value of ${hz}. Must be between 0.1e13 and 1000`);
   }
 
-  return function queue(params: any, routineEmitter: NodeJS.EventEmitter): Queue {
+  return function queue(params: any, routineEmitter: (frameId: number) => any): Queue {
     let timer: NodeJS.Timer = null;
     let numPackets = 0;
     let totalBytes = 0;
@@ -18,7 +18,7 @@ export function dynamic({
     function _step(): void {
       clearTimeout(timer);
       timer = null;
-      routineEmitter.emit('runQueue', { frameId, numPackets });
+      routineEmitter(frameId);
       if (++frameId > 0xffff) frameId = 0;
       numPackets = 0;
       totalBytes = 0;
@@ -56,6 +56,6 @@ export function dynamic({
       _add(packet);
     }
 
-    return { add, flush: _step, emitter: routineEmitter };
+    return { add, flush: _step, size: () => numPackets };
   };
 }

--- a/packages/kalm/src/routines/realtime.ts
+++ b/packages/kalm/src/routines/realtime.ts
@@ -1,16 +1,16 @@
 /* Methods -------------------------------------------------------------------*/
 
 export function realtime(): KalmRoutine {
-  return function queue(params: object, routineEmitter: NodeJS.EventEmitter): Queue {
+  return function queue(params: object, routineEmitter: (frameId: number) => any): Queue {
     let frameId: number = 0;
 
     function add(): void {
-      routineEmitter.emit('runQueue', { frameId });
+      routineEmitter(frameId);
       if (++frameId > 0xffff) frameId = 0;
     }
 
     function flush(): void {}
 
-    return { add, flush, emitter: routineEmitter };
+    return { add, flush, size: () => 0 };
   };
 }

--- a/packages/kalm/src/routines/tick.ts
+++ b/packages/kalm/src/routines/tick.ts
@@ -7,18 +7,21 @@ export function tick({ hz, seed = 0 }: { hz: number, seed?: number }): KalmRouti
 
   let frameId: number = seed || 0;
 
-  return function queue(params: object, routineEmitter: NodeJS.EventEmitter): Queue {
+  return function queue(params: object, routineEmitter: (frameId: number) => any): Queue {
     let timer: NodeJS.Timer = null;
+    let numPackets: number = 0;
 
     function _step(): void {
       frameId++;
-      routineEmitter.emit('runQueue', { frameId });
+      routineEmitter(frameId);
+      numPackets = 0;
     }
 
     function add(): void {
+      numPackets++;
       if (timer === null) timer = setInterval(_step, 1000 / hz);
     }
 
-    return { add, flush: _step, emitter: routineEmitter };
+    return { add, flush: _step, size: () => numPackets };
   };
 }

--- a/packages/kalm/types.d.ts
+++ b/packages/kalm/types.d.ts
@@ -70,7 +70,7 @@ declare module 'kalm' {
     type SocketHandle = NodeJS.Socket | UDPSocketHandle | WebSocket
 
     interface KalmRoutine {
-        (channel: string, params: any, channelEmitter: NodeJS.EventEmitter, clientEmitter: NodeJS.EventEmitter): Queue
+        (channel: string, params: any, channelEmitter: (frameId: number) => any): Queue
     }
     interface Queue {
         add: (packet: Buffer) => void

--- a/packages/tcp/README.md
+++ b/packages/tcp/README.md
@@ -37,4 +37,4 @@ If you think of something that you want, [open an issue](//github.com/kalm/kalm.
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/tcp/package.json
+++ b/packages/tcp/package.json
@@ -45,11 +45,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/tcp/package.json
+++ b/packages/tcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalm/tcp",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "TCP transport for Kalm",
   "main": "bin/tcp.js",
   "scripts": {

--- a/packages/udp/README.md
+++ b/packages/udp/README.md
@@ -41,4 +41,4 @@ If you think of something that you want, [open an issue](//github.com/kalm/kalm.
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/udp/package.json
+++ b/packages/udp/package.json
@@ -45,11 +45,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/udp/package.json
+++ b/packages/udp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalm/udp",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "UDP transport for Kalm",
   "main": "bin/udp.js",
   "scripts": {

--- a/packages/udp/src/udp.ts
+++ b/packages/udp/src/udp.ts
@@ -38,7 +38,7 @@ function udp({ type = 'udp4', localAddr = '0.0.0.0', reuseAddr = false, socketTi
         return;
       }
       if (handle && handle.socket) {
-        handle.socket.send(JSON.stringify(payload), handle.port, handle.host);
+        handle.socket.send(payloadBytes, handle.port, handle.host);
       }
     }
 

--- a/packages/webrtc/README.md
+++ b/packages/webrtc/README.md
@@ -37,4 +37,4 @@ If you think of something that you want, [open an issue](//github.com/kalm/kalm.
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -45,11 +45,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalm/webrtc",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "WebRTC transport for Kalm",
   "main": "bin/webrtc.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "frederic charette <fredericcharette@gmail.com>"
   ],
   "dependencies": {
-    "simple-peer": "^9.6.0"
+    "simple-peer": "^9.11.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -39,4 +39,4 @@ If you think of something that you want, [open an issue](//github.com/kalm/kalm.
 
 ## License 
 
-[Apache 2.0](LICENSE) (c) 2020 Frederic Charette
+[Apache 2.0](LICENSE) (c) 2022 Frederic Charette

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -49,11 +49,12 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": [
+      "ts-jest", {
         "diagnostics": false,
         "isolatedModules": true
-      }
+      }]
     }
   }
 }

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalm/ws",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "WebSocket transport for Kalm",
   "main": "bin/ws.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "frederic charette <fredericcharette@gmail.com>"
   ],
   "dependencies": {
-    "ws": "^7.4.0"
+    "ws": "^8.9.0"
   },
   "browser": {
     "http": false,

--- a/tests/integration/index.spec.ts
+++ b/tests/integration/index.spec.ts
@@ -71,7 +71,7 @@ describe('Integration tests', () => {
       });
 
       it(`should handle large payloads with ${transport}`, done => {
-        const largePayload = [];
+        const largePayload: { foo: string }[] = [];
         while (largePayload.length < 2048) {
           largePayload.push({ foo: 'bar' });
         }
@@ -88,6 +88,10 @@ describe('Integration tests', () => {
 
         const client = connect({ transport: soc });
         client.on('error', e => {
+          if (transport === 'udp') {
+            expect(e.message).toEqual('UDP Cannot send packets larger than 16384 bytes, tried to send 28715 bytes');
+            return done();
+          }
           throw new Error(e);
         });
         client.write('test.large', largePayload);

--- a/types.d.ts
+++ b/types.d.ts
@@ -70,12 +70,12 @@ type UDPClientList = {
 type SocketHandle = NodeJS.Socket | UDPSocketHandle | WebSocket
 
 interface KalmRoutine {
-    (params: any, routineEmitter: NodeJS.EventEmitter): Queue
+    (params: any, routineEmitter: (frameId: number) => any): Queue
 }
 interface Queue {
     add: (packet: any) => void
+    size: () => number
     flush: () => void
-    emitter: NodeJS.EventEmitter
 }
 
 interface KalmTransport {


### PR DESCRIPTION
# v6.1.0

* This branch does not include QUIC support *

## Major changes

- Removed SYN/ACK UDP connection check system, which removes the socket timeout behaviour for that transport
- Added error event for UDP packet over the safe limit (16384 bytes), previous behaviour was to crash silently
- Routines are no longer event emitters, but have a size function

UDP throughput is now **20% higher**

## Cleanup

- Updated dependencies
- Fixed READMEs
- Added Node 18 in test matrix
- Fixed ts-jest config